### PR TITLE
Optimize `bfcache` api support

### DIFF
--- a/components/gatracker/default.htm
+++ b/components/gatracker/default.htm
@@ -1,9 +1,21 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ __SELF__.measurementId }}"></script>
 <script>
 window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+function gtag() {
+    dataLayer.push(arguments);
+}
+gtag("js", new Date());
 
-    gtag('config', '{{ __SELF__.measurementId }}');
-    gtag('config', '{{ __SELF__.conversionId }}'); // Wrap in an if statement
+gtag("config", "{{ __SELF__.measurementId }}");
+gtag("config", "{{ __SELF__.conversionId }}"); // Wrap in an if statement
+
+// Send a pageview when the page is first loaded.
+gtag("event", "page_view");
+
+window.addEventListener("pageshow", function (event) {
+    if (event.persisted === true) {
+        // Send another pageview if the page is restored from bfcache.
+        gtag("event", "page_view");
+    }
+});
 </script>


### PR DESCRIPTION
If you track visits to your site with an analytics tool, you will likely notice a decrease in the total number of pageviews reported as Chrome continues to enable bfcache for more users.

In fact, you're likely already underreporting pageviews from other browsers that implement bfcache since most of the popular analytics libraries do not track bfcache restores as new pageviews.

This pr fixes this issue.

Github issue: https://github.com/ayumi-cloud/ga4/issues/8
